### PR TITLE
DOC-1104 Amended throttling strategy

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -62,10 +62,10 @@ export const config = convict({
     },
   },
   migration: {
-    maxDocumentsPerSecond: {
-      env: "MIGRATION_MAX_DOCUMENTS_PER_SECOND",
+    maxConcurrentDocuments: {
+      env: "MIGRATION_MAX_CONCURRENT_DOCUMENTS",
       format: Number,
-      default: 100,
+      default: 32,
     },
     maxRetriesPerDocument: {
       env: "MIGRATION_MAX_RETRIES_PER_DOCUMENT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,7 @@ const blobToS3CopyStream = new BlobToS3CopyStream({
 });
 const throttledCopyStream = new ThrottledTransformStream(blobToS3CopyStream, {
   objectMode: true,
-  queriesPerSecond: config.migration.maxDocumentsPerSecond,
-  uniformDistribution: true,
+  maxConcurrency: config.migration.maxConcurrentDocuments,
 });
 
 pipeline(blobListStream, blobFilterStream, throttledCopyStream, (err) => {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1104

## Describe this PR

This PR amends the throttling strategy so that it is no longer rate limited per second and just limits the amount of concurrent document downloads instead.

### *What changes have we introduced*

Amended the throttling logic in the `ThrottledTransformStream` to use a semaphore rather than a rate limiter.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [x] Code pipeline builds correctly