### PR TITLE
DOC-1104 Catch and log failed HeadObject requests

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -103,7 +103,9 @@ export class S3Bucket {
       );
     } catch (err) {
       if (err instanceof Error && err.name !== "NotFound") {
-        throw err;
+        this.logger.error(err, {
+          objectName: mappedName,
+        });
       }
 
       return false;

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -197,29 +197,35 @@ describe("S3Bucket", () => {
       expect(actual).toEqual(expected);
     });
 
-    test("successfully throws on failure", async () => {
+    test("successfully handles a failure", async () => {
       const bucketName = "test";
       const blobName = "test.txt";
       const blobContentLength = 6;
       const error = new Error("Test Error");
 
-      const expected = error;
+      const expected = false;
 
       const mockS3Client = partial<S3Client>({
         send: () => Promise.reject(error),
       });
 
-      const mockLogger = partial<Logger>({});
+      const mockLoggerError = jest.fn();
+      const mockLogger = partial<Logger>({
+        error: mockLoggerError,
+      });
 
       const s3Bucket = new S3Bucket({
         s3Client: mockS3Client,
         name: bucketName,
         logger: mockLogger,
       });
+      const actual = await s3Bucket.doesObjectExist(
+        blobName,
+        blobContentLength
+      );
 
-      await expect(
-        s3Bucket.doesObjectExist(blobName, blobContentLength)
-      ).rejects.toThrowError(expected);
+      expect(actual).toEqual(expected);
+      expect(mockLoggerError).toBeCalled();
     });
   });
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1104

## Describe this PR

This PR stops failed HeadObject requests from stopping the script.

### *What changes have we introduced*

Failed HeadObject requests are now logged and the script attempts to copy the file over anyway.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Code pipeline builds correctly