### PR TITLE
DOC-1104 Amended the way that prefixes are handled

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,3 @@
-import path from "path";
 import {
   BlobServiceClient as BlobClient,
   ContainerClient,
@@ -84,9 +83,9 @@ export class BlobContainer implements DocumentSource {
   }
 
   async getDocumentContent(name: string): Promise<DocumentContent> {
-    const blobItemClient = this.client.getBlobClient(
-      path.join(this.prefix, name)
-    );
+    const fullName = `${this.prefix}${name}`;
+
+    const blobItemClient = this.client.getBlobClient(fullName);
     const blobDownloadResponse = await blobItemClient.download();
 
     return {
@@ -170,6 +169,6 @@ export class S3Bucket implements DocumentDestination {
   }
 
   private mapObjectName(name: string): string {
-    return path.join(this.prefix, name);
+    return `${this.prefix}${name}`;
   }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-1104

## Describe this PR

This PR adds changes the way that file prefixes are handled for both Azure Blob Storage and AWS S3.

### *What changes have we introduced*

Removed the use of `path.join` for adding prefixes to file names as the prefixes in Azure Blob Storage and AWS S3 aren't really folders and are just the beginning of the full name of the file. The code now just concatenates the prefixes onto the start of the file name.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [x] Code pipeline builds correctly